### PR TITLE
Fixed "rev" key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ Hooks for [pre-commit](https://pre-commit.com) that validate Markdown / RST file
 ## Usage
 
     - repo: https://github.com/Lucas-C/pre-commit-hooks-markup
-      sha: v1.0.0
+      rev: v1.0.0
       hooks:
       - id: rst-linter


### PR DESCRIPTION
With the original "sha", pre-commit 2.1.1 logs the following warning:

> [WARNING] Unexpected key(s) present on https://github.com/Lucas-C/pre-commit-hooks-markup: sha