### PR TITLE
Add the --raw-enable option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Hooks for [pre-commit](https://pre-commit.com) that validate Markdown / RST file
 To enable the `.. raw::` directive, you can add:
 
       - id: rst-linter
-        args: [--raw-enable]
+        args: [--allow-raw]
 
 Note that this is a potential security hole, and will prevent rendering of the
 `README.rst` file on PyPI.

--- a/README.md
+++ b/README.md
@@ -9,3 +9,16 @@ Hooks for [pre-commit](https://pre-commit.com) that validate Markdown / RST file
       rev: v1.0.0
       hooks:
       - id: rst-linter
+
+To enable the `.. raw::` directive, you can add:
+
+      - id: rst-linter
+        args: [--raw-enable]
+
+Note that this is a potential security hole, and will prevent rendering of the
+`README.rst` file on PyPI.
+See [docutils documentation][1] and [Python Packaging User Guide][2]
+for more information.
+
+[1]: https://docutils.sourceforge.io/docs/ref/rst/directives.html
+[2]: https://packaging.python.org/guides/making-a-pypi-friendly-readme/

--- a/pre_commit_hooks/rst_linter.py
+++ b/pre_commit_hooks/rst_linter.py
@@ -8,12 +8,12 @@ from readme_renderer.rst import publish_parts, ReadMeHTMLTranslator, SETTINGS, S
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='filenames to check')
-    parser.add_argument('-r', '--raw-enabled', action='store_true', help='Allow the "raw" directive')
+    parser.add_argument('-r', '--allow-raw', action='store_true', help='Allow the "raw" directive')
     args = parser.parse_args(argv)
 
     errors_found = False
     for filename in args.filenames:
-        linter_error = get_linter_error(filename, args.raw_enabled)
+        linter_error = get_linter_error(filename, args.allow_raw)
         if linter_error:
             errors_found = True
             print('Syntax error found in ', filename, file=sys.stderr)
@@ -22,12 +22,12 @@ def main(argv=None):
     return 1 if errors_found else 0
 
 
-def get_linter_error(filename, raw_enabled):
+def get_linter_error(filename, allow_raw):
     output = io.StringIO()
 
     settings = SETTINGS.copy()
     settings['warning_stream'] = output
-    settings['raw_enabled'] = raw_enabled
+    settings['raw_enabled'] = allow_raw
 
     writer = Writer()
     writer.translator_class = ReadMeHTMLTranslator

--- a/pre_commit_hooks/rst_linter.py
+++ b/pre_commit_hooks/rst_linter.py
@@ -8,11 +8,12 @@ from readme_renderer.rst import publish_parts, ReadMeHTMLTranslator, SETTINGS, S
 def main(argv=None):
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*', help='filenames to check')
+    parser.add_argument('-r', '--raw-enabled', action='store_true', help='Allow the "raw" directive')
     args = parser.parse_args(argv)
 
     errors_found = False
     for filename in args.filenames:
-        linter_error = get_linter_error(filename)
+        linter_error = get_linter_error(filename, args.raw_enabled)
         if linter_error:
             errors_found = True
             print('Syntax error found in ', filename, file=sys.stderr)
@@ -21,11 +22,12 @@ def main(argv=None):
     return 1 if errors_found else 0
 
 
-def get_linter_error(filename):
+def get_linter_error(filename, raw_enabled):
     output = io.StringIO()
 
     settings = SETTINGS.copy()
     settings['warning_stream'] = output
+    settings['raw_enabled'] = raw_enabled
 
     writer = Writer()
     writer.translator_class = ReadMeHTMLTranslator


### PR DESCRIPTION
This option makes the linter allow the `.. raw::` directive. I needed this in [Darker](https://github.com/akaihola/darker) since I maintain the contributors table shown on GitHub in `README.rst` as raw HTML, and strip it out programmatically when creating distribution archives.