### PR TITLE
GitHub Action: max-parallel 1 to avoid db conflicts?

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      max-parallel: 5
+      max-parallel: 1  # Avoid database corruption?
       matrix:
         python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     steps:


### PR DESCRIPTION
This cannot be it.  These are separate Docker images.